### PR TITLE
fix(security): harden Neo4j credential and relationship validation

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,7 +4,8 @@
 # Neo4j Configuration
 NEO4J_URI=bolt://localhost:7687
 NEO4J_USER=neo4j
-NEO4J_PASSWORD=librarian-pass
+# Required: Neo4j database password (no hardcoded default — must be set explicitly)
+NEO4J_PASSWORD=your_secure_password_here
 NEO4J_DATABASE=neo4j
 
 # Connection Pool Settings

--- a/src/graph/operations.py
+++ b/src/graph/operations.py
@@ -88,7 +88,6 @@ def validate_label(label: str) -> bool:
     Validate that a label is from the allowed set.
 
     DEPRECATED: Use validate_node_label() from schema module instead.
-    Kept for backward compatibility.
 
     Args:
         label: Node label to validate
@@ -97,31 +96,6 @@ def validate_label(label: str) -> bool:
         True if valid, False otherwise
     """
     return label in ALLOWED_NODE_LABELS
-
-
-def validate_relationship_type(rel_type: str) -> bool:
-    """
-    Validate that a relationship type is from the allowed set.
-
-    Args:
-        rel_type: Relationship type to validate
-
-    Returns:
-        True if valid, False otherwise
-    """
-    allowed_types = {
-        RelationshipTypes.IMPLEMENTS,
-        RelationshipTypes.DEFINES,
-        RelationshipTypes.MODIFIES,
-        RelationshipTypes.DEPENDS_ON,
-        RelationshipTypes.SUPERSEDES,
-        RelationshipTypes.REFERENCES,
-        RelationshipTypes.TRIGGERS,
-        RelationshipTypes.HAS_CHUNK,
-        RelationshipTypes.SIMILAR_TO
-    }
-
-    return rel_type in allowed_types
 
 
 class GraphOperations:
@@ -338,13 +312,10 @@ class GraphOperations:
         Raises:
             ValueError: If either node doesn't exist
         """
-        # Validate labels and relationship type
-        if not validate_label(from_label):
-            raise ValueError(f"Invalid source node label: {from_label}")
-        if not validate_label(to_label):
-            raise ValueError(f"Invalid target node label: {to_label}")
-        if not validate_relationship_type(rel_type):
-            raise ValueError(f"Invalid relationship type: {rel_type}")
+        # Validate labels and relationship type (raises ValueError if invalid)
+        validate_node_label(from_label)
+        validate_node_label(to_label)
+        validate_relationship_type(rel_type)
 
         properties = properties or {}
 


### PR DESCRIPTION
## Summary

- Replaces hardcoded Neo4j password example in .env.template with an explicit secure placeholder.
- Removes duplicated relationship type validation logic and uses centralized schema validators in graph operations.

## Notes

- Auto-committed by cleanup agent from existing in-progress branch work.
- No default-branch merge performed.
